### PR TITLE
import from CommentedSeq from ruamel.yaml.comments instead of ruamel.…

### DIFF
--- a/src/souschef/section.py
+++ b/src/souschef/section.py
@@ -2,8 +2,7 @@ import weakref
 from collections import abc
 from typing import Mapping, Union
 
-from ruamel.yaml import CommentedSeq
-from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from souschef import mixins
 from souschef.tools import parse_value


### PR DESCRIPTION
…yaml

Not sure when this changed. I'm using ruamel.yaml version '0.16.12'. If there's a different approach you want to take that's fine too.