### PR TITLE
Add outputs section

### DIFF
--- a/src/souschef/recipe.py
+++ b/src/souschef/recipe.py
@@ -19,6 +19,7 @@ class Recipe(mixins.GetSetItemMixin, mixins.InlineCommentMixin, mixins.AddSectio
         "build",
         "requirements",
         "test",
+        "outputs",
         "about",
         "extra",
     )

--- a/src/souschef/section.py
+++ b/src/souschef/section.py
@@ -1,6 +1,6 @@
 import weakref
 from collections import abc
-from typing import Mapping, Union
+from typing import Any, Union
 
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
@@ -55,7 +55,7 @@ class Section(
         return [v for v in self]
 
     @value.setter
-    def value(self, items):
+    def value(self, items: Any):
         if isinstance(items, abc.Mapping):
             for key, value in items.items():
                 self[key] = value
@@ -73,6 +73,5 @@ class Section(
         else:
             self._parent()[self._name] = items
 
-    def update(self, section: Mapping):
-        for k, val in section.items():
-            self[k] = val
+    def update(self, section: Any):
+        self.value = section


### PR DESCRIPTION
Issues: conda-forge linting complains that the `outputs` section is on the wrong place:

https://github.com/conda-forge/pypushflow-feedstock/pull/1#issuecomment-1231757611

@marcelotrevisani It seems that the `Section.value` setter is not setting but updating, which makes `Section.update` redundant.